### PR TITLE
Make `chainzip` more robust

### DIFF
--- a/src/RelevancePropagation.jl
+++ b/src/RelevancePropagation.jl
@@ -10,6 +10,7 @@ using Flux
 using Zygote
 using Markdown
 
+include("compat.jl")
 include("bibliography.jl")
 include("layer_types.jl")
 include("layer_utils.jl")

--- a/src/chain_utils.jl
+++ b/src/chain_utils.jl
@@ -156,11 +156,16 @@ function chainzip(f, xs...)
     if all(isleaf, xs)
         return f(xs...)
     else
-        constructors = constructor.(xs)
-        T = first(constructors)
-        # Assume that arguments xs are zippable if constructors match:
-        all(c -> c == T, constructors) || error("Cannot chainzip arguments $xs.")
-        vals = chainzip.(f, children.(xs)...)
+        Ts = constructor.(xs)
+        allequal(Ts) || error("Cannot chainzip arguments of different container types $Ts.")
+
+        cs = children.(xs)
+        lens = length.(cs)
+        allequal(lens) ||
+            error("Cannot chainzip arguments $xs of different lengths: $lens.")
+
+        T = first(Ts)
+        vals = chainzip.(f, cs...)
         return T(vals...)
     end
 end

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,6 @@
+if VERSION < v"1.8.0-DEV.1494" # 98e60ffb11ee431e462b092b48a31a1204bd263d
+    export allequal
+    allequal(itr) = isempty(itr) ? true : all(isequal(first(itr)), itr)
+    allequal(c::Union{AbstractSet,AbstractDict}) = length(c) <= 1
+    allequal(r::AbstractRange) = iszero(step(r)) || length(r) <= 1
+end

--- a/test/test_chain_utils.jl
+++ b/test/test_chain_utils.jl
@@ -1,5 +1,5 @@
 using RelevancePropagation: ChainTuple, ParallelTuple, SkipConnectionTuple
-using RelevancePropagation: ModelIndex, chainmap, chainindices
+using RelevancePropagation: ModelIndex, chainmap, chainindices, chainzip
 using RelevancePropagation: activation_fn
 using Flux
 
@@ -71,3 +71,20 @@ const MI = ModelIndex
 @test ModelIndex(1, 2) ∈ ModelIndex(1, 2)
 @test ModelIndex(1, 2, 3) ∈ ModelIndex(1, 2)
 @test ModelIndex(1, 2) ∉ ModelIndex(1, 2, 3)
+
+# Test chainzip
+t1 = ChainTuple(1, 2, 3)
+t2 = ChainTuple(4, 5, 6)
+t3 = ChainTuple(7, 8, 9)
+@test chainzip(+, t1, t2) == ChainTuple(5, 7, 9)
+@test chainzip(+, t1, t2, t3) == ChainTuple(12, 15, 18)
+@test chainzip(*, t1, t2, t3) == ChainTuple(28, 80, 162)
+
+@test chainzip(
+    +,
+    ChainTuple(1, ChainTuple(ParallelTuple(2, ChainTuple(3)))),
+    ChainTuple(4, ChainTuple(ParallelTuple(5, ChainTuple(6)))),
+) == ChainTuple(5, ChainTuple(ParallelTuple(7, ChainTuple(9))))
+
+@test_throws ErrorException chainzip(+, t1, ChainTuple(1, 2))
+@test_throws ErrorException chainzip(+, t1, ParallelTuple(1, 2, 3))


### PR DESCRIPTION
`chainzip` now asserts lengths of children and prints more informative error messages.

CC: @Maximilian-Stefan-Ernst